### PR TITLE
feat: use Scarf Gateway for Superset helm charts/Docker compose/npm downloads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-x-superset-image: &superset-image apache/superset:${TAG:-latest-dev}
+x-superset-image: &superset-image apachesuperset.docker.scarf.sh/apache/superset:${TAG:-latest-dev}
 x-superset-user: &superset-user root
 x-superset-depends-on: &superset-depends-on
   - db

--- a/helm/superset/values.yaml
+++ b/helm/superset/values.yaml
@@ -176,7 +176,7 @@ configMountPath: "/app/pythonpath"
 extraConfigMountPath: "/app/configs"
 
 image:
-  repository: apache/superset
+  repository: apachesuperset.docker.scarf.sh/apache/superset
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -204,6 +204,7 @@
     "regenerator-runtime": "^0.13.5",
     "rimraf": "^3.0.2",
     "rison": "^0.1.1",
+    "scarf-js": "^1.1.1",
     "scroll-into-view-if-needed": "^2.2.28",
     "shortid": "^2.2.6",
     "tinycolor2": "^1.4.2",
@@ -345,6 +346,9 @@
     "webpack-dev-server": "^4.10.1",
     "webpack-manifest-plugin": "^4.0.2",
     "webpack-sources": "^3.2.0"
+  },
+  "scarfSettings": {
+    "allowTopLevel": true
   },
   "engines": {
     "node": "^16.9.1",


### PR DESCRIPTION
### SUMMARY
This PR updates the Superset configuration for helm charts, Docker compose, and npm to fetch Superset containers via a Scarf endpoint, so that Superset maintainers can collect basic de-identified download and adoption metrics. It does not affect where the containers are being hosted, as Scarf is only redirecting traffic back to Docker Hub. 

This change was suggested by Superset maintainers in direct discussions. 

### TESTING INSTRUCTIONS
To test this, download Apache Superset using the new endpoint (e.g. docker pull apachesuperset.docker.scarf.sh/apache/superset) and verify that the apache/superset container downloads without issue. 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ x ] Introduces new feature or API
- [ ] Removes existing feature or API
