### PR TITLE
feat: use Scarf Gateway for Superset npm downloads

### DIFF
--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -204,6 +204,7 @@
     "regenerator-runtime": "^0.13.5",
     "rimraf": "^3.0.2",
     "rison": "^0.1.1",
+    "scarf-js": "^1.1.1",
     "scroll-into-view-if-needed": "^2.2.28",
     "shortid": "^2.2.6",
     "tinycolor2": "^1.4.2",
@@ -345,6 +346,9 @@
     "webpack-dev-server": "^4.10.1",
     "webpack-manifest-plugin": "^4.0.2",
     "webpack-sources": "^3.2.0"
+  },
+  "scarfSettings": {
+    "allowTopLevel": true
   },
   "engines": {
     "node": "^16.9.1",


### PR DESCRIPTION
### SUMMARY

This PR updates the Superset configuration for npm by adding scarf-js as a dependency. This allows Superset maintainers to collect basic de-identified download and adoption metrics. It does not affect where Superset is being hosted, as scarf-js is only acting as a dependency of superset-frontend.

This change was suggested by Superset maintainers in direct discussions.

### TESTING INSTRUCTIONS
To test this, download Apache Superset using the same npm methodology and verify that Apache Superset downloads without issue.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ x ] Introduces new feature or API
- [ ] Removes existing feature or API